### PR TITLE
Support a wider range for AppAuth podspec

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,7 +38,7 @@
         </config-file>
         <header-file src="src/ios/OIDCBasic.h" />
         <source-file src="src/ios/OIDCBasic.m" />
-        <framework src="AppAuth" type="podspec" spec="~> 1.3.0" />
+        <framework src="AppAuth" type="podspec" spec="~> 1.3" />
     </platform>
 
     <!-- android -->


### PR DESCRIPTION
Using the plugin cordova-plugin-oidc-basic along with [cordova-plugin-firebasex](https://github.com/dpa99c/cordova-plugin-firebasex) on iOS platform raises the following conflict due to AppAuth podspec:
```
[!] CocoaPods could not find compatible versions for pod "AppAuth":
  In snapshot (Podfile.lock):
    AppAuth (= 1.3.1, ~> 1.3.0)

  In Podfile:
    AppAuth (~> 1.3.0)

    GoogleSignIn (= 6.2.1) was resolved to 6.2.1, which depends on
      AppAuth (~> 1.5)
```

The constraint of setting the AppAuth podspec to `~> 1.3.0` in cordova-plugin-oidc-basic might be too restrictive.